### PR TITLE
feat: Add edit and update functionality for blog posts

### DIFF
--- a/src/routes/querriesRoutes.js
+++ b/src/routes/querriesRoutes.js
@@ -15,4 +15,6 @@ router.put('/queries/update/:id', updateQuery);
 // Delete a query
 router.delete('/queries/delete/:id',deleteQuery);
 
+
+
 export default router;


### PR DESCRIPTION
This commit adds the ability for users to edit and update their blog posts. The editBlog function is called when the edit button is clicked, which opens a form with the current blog post information pre-populated. When the form is submitted, the updateBlog function is called to send a PUT request to the server with the updated blog post information. If the update is successful, the user is given a success message and the blog post list is re-rendered with the updated post.